### PR TITLE
Publication-workflow

### DIFF
--- a/app/Actions/BuildSolrIndexQuery.php
+++ b/app/Actions/BuildSolrIndexQuery.php
@@ -346,6 +346,8 @@ SQL;
             'raps.registered_aboriginal_parties'
         );
 
+        $query->addSelect('t.publicaton_status');
+
         return $query;
     }
 }

--- a/app/GraphQL/Enums/PublicationStatusEnum.graphql
+++ b/app/GraphQL/Enums/PublicationStatusEnum.graphql
@@ -1,0 +1,4 @@
+enum PublicationStatusEnum {
+  DRAFT @enum(value: "draft")
+  PUBLISHED @enum(value: "published")
+}

--- a/app/GraphQL/Mutations/CreateTaxonConcept.php
+++ b/app/GraphQL/Mutations/CreateTaxonConcept.php
@@ -73,6 +73,7 @@ class CreateTaxonConcept
                     DegreeOfEstablishment::where('name', 
                     $input['degreeOfEstablishment'])->value('id');
         }
+        $input['publication_status'] = $input['publicationStatus'];
         $taxonConcept = TaxonConcept::create($input);
         return $taxonConcept;
     }

--- a/app/GraphQL/Mutations/CreateUserPreferences.php
+++ b/app/GraphQL/Mutations/CreateUserPreferences.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\UserPreferences;
+
+final class CreateUserPreferences
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args): UserPreferences
+    {
+        $input = $args['input'];
+        $preferences = new UserPreferences;
+        $preferences->user_id = $input['user']['connect'];
+        if (isset($input['defaultPublicationStatus'])) {
+            $preferences->default_publication_status 
+                    = $input['defaultPublicationStatus'];
+        }
+        $preferences->save();
+        return $preferences;
+    }
+}

--- a/app/GraphQL/Mutations/UpdateTaxonConcept.php
+++ b/app/GraphQL/Mutations/UpdateTaxonConcept.php
@@ -67,7 +67,8 @@ class UpdateTaxonConcept
 
         $taxonConcept = TaxonConcept::where('guid', $input['guid'])->first();
         if ($input['taxonomic_status_id'] != $taxonConcept->taxonomic_status_id 
-                || $input['accepted_id'] != $taxonConcept->accepted_id) {
+                || (isset($input['accepted_id']) && $input['accepted_id'] != $taxonConcept->accepted_id)
+                || (!isset($input['accepted_id']) && $taxonConcept->accepted_id)) {
             $change = new Change();
             $change->guid = Str::uuid();
             $change->from_id = $taxonConcept->id;
@@ -81,7 +82,7 @@ class UpdateTaxonConcept
             $change->created_by_id = Agent::where('user_id', Auth::id())->value('id');
             $change->save();
         }
-
+        $taxonConcept->publication_status = $input['publicationStatus'];
 
         $taxonConcept->update($input);
         $taxonConcept->increment('version');

--- a/app/GraphQL/Mutations/UpdateUserPreferences.php
+++ b/app/GraphQL/Mutations/UpdateUserPreferences.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\UserPreferences;
+
+final class UpdateUserPreferences
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args): UserPreferences
+    {
+        $input = $args['input'];
+        $preferences = UserPreferences
+                ::where('user_id', $input['user']['connect'])->first();
+        $preferences->default_publication_status 
+                = $input['defaultPublicationStatus'];
+        $preferences->save();
+        return $preferences;
+    }
+}

--- a/app/GraphQL/Queries/TaxonConcept.php
+++ b/app/GraphQL/Queries/TaxonConcept.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\TaxonConcept as Concept;
+use Illuminate\Support\Facades\Auth;
+
+final class TaxonConcept
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $taxonConcept = Concept::where('guid', $args['id'])->first();
+
+        if ($taxonConcept->publication_status === 'draft'
+                && !Auth::check()) {
+            return null;
+        }
+
+        return $taxonConcept;
+    }
+}

--- a/app/GraphQL/Types/TaxonConcept.graphql
+++ b/app/GraphQL/Types/TaxonConcept.graphql
@@ -282,6 +282,14 @@ type TaxonConcept {
 
     changes: [Change]
 
+    """
+    Publication status creates a rudimentary publication workflow. A Taxon 
+    Concept can be 'draft' or 'published'. 'draft' Taxon Concepts are only 
+    visible to VicFlora editors.
+    """
+    publicationStatus: PublicationStatusEnum! 
+        @rename(attribute: "publication_status")
+
     createdBy: Agent
     modifiedBy: Agent
     createdAt: DateTimeTz @rename(attribute: "created_at")
@@ -303,6 +311,7 @@ input CreateTaxonConceptInput {
     hasIntroducedOccurrences: Boolean 
             @rename(attribute: "has_introduced_occurrences")
     remarks: String
+    publicationStatus: PublicationStatusEnum!
 }
 
 input UpdateTaxonConceptInput {
@@ -320,6 +329,7 @@ input UpdateTaxonConceptInput {
     hasIntroducedOccurrences: Boolean 
             @rename(attribute: "has_introduced_occurrences")
     remarks: String
+    publicationStatus: PublicationStatusEnum
 }
 
 input TaxonConceptBelongsTo {
@@ -340,8 +350,9 @@ type IdentificationKey {
 }
 
 extend type Query {
-    taxonConcept(id: ID! @eq(key: "guid")): TaxonConcept @find
-
+    taxonConcept(id: ID!): TaxonConcept 
+        @field(resolver: "\\App\\GraphQL\\Queries\\TaxonConcept")
+        
     taxonConceptsByWkt(wkt: String!): [TaxonConcept]!
         @paginate(
             type: PAGINATOR

--- a/app/GraphQL/Types/User.graphql
+++ b/app/GraphQL/Types/User.graphql
@@ -3,6 +3,37 @@ type User {
     name: String!
     email: String!
     agent: Agent!
+    preferences: UserPreferences! @rename(attribute: "userPreferences")
     created_at: DateTime!
     updated_at: DateTime!
+}
+
+type UserPreferences {
+    user: User!
+    defaultPublicationStatus: PublicationStatusEnum! 
+            @rename(attribute: "default_publication_status")
+}
+
+input CreateUserPreferencesInput {
+    user: UserBelongsTo!
+    defaultPublicationStatus: PublicationStatusEnum!
+}
+
+input UpdateUserPreferencesInput {
+    user: UserBelongsTo!
+    defaultPublicationStatus: PublicationStatusEnum!
+}
+
+input UserBelongsTo {
+    connect: ID!
+}
+
+extend type Mutation {
+    createUserPreferences(input: CreateUserPreferencesInput!): UserPreferences! 
+        @guard(with: ["api"])
+        @field(resolver: "\\App\\GraphQL\\Mutations\\CreateUserPreferences")
+
+    updateUserPreferences(input: UpdateUserPreferencesInput!): UserPreferences! 
+        @guard(with: ["api"])
+        @field(resolver: "\\App\\GraphQL\\Mutations\\UpdateUserPreferences")
 }

--- a/app/Models/TaxonConcept.php
+++ b/app/Models/TaxonConcept.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Staudenmeir\LaravelCte\Eloquent\QueriesExpressions;
 
@@ -273,7 +274,7 @@ class TaxonConcept extends BaseModel
     public function getChildrenAttribute(): Collection
     {
         if ($this->taxonomicStatus->name === 'accepted') {
-            return TaxonConcept::select('taxon_concepts.*', 'taxon_names.full_name')
+            $query = TaxonConcept::select('taxon_concepts.*', 'taxon_names.full_name')
                 ->join('taxonomic_statuses', 
                         'taxon_concepts.taxonomic_status_id', '=', 
                         'taxonomic_statuses.id')
@@ -281,8 +282,13 @@ class TaxonConcept extends BaseModel
                         'taxon_names.id')
                 ->where('taxon_concepts.parent_id', $this->id)
                 ->where('taxonomic_statuses.name', 'accepted')
-                ->orderBy('full_name')
-                ->get();
+                ->orderBy('full_name');
+
+            if (!Auth::check()) {
+                $query->where('publication_status', 'published');
+            }
+            
+            return $query->get();
         }
         return collect([]);
     }
@@ -293,7 +299,7 @@ class TaxonConcept extends BaseModel
     public function getSiblingsAttribute(): Collection
     {
         if ($this->taxonomicStatus->name === 'accepted') {
-            return TaxonConcept::select('taxon_concepts.*', 
+            $query = TaxonConcept::select('taxon_concepts.*', 
                     'taxon_names.full_name')
                 ->join('taxonomic_statuses', 
                         'taxon_concepts.taxonomic_status_id', '=', 
@@ -302,8 +308,13 @@ class TaxonConcept extends BaseModel
                         'taxon_names.id')
                 ->where('taxon_concepts.parent_id', $this->parent_id)
                 ->where('taxonomic_statuses.name', 'accepted')
-                ->orderBy('full_name')
-                ->get();
+                ->orderBy('full_name');
+
+            if (!Auth::check()) {
+                $query->where('publication_status', 'published');
+            }
+            
+            return $query->get();
         }
         return collect([]);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -43,8 +43,23 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
 
+    /**
+     * Get the agent for which this is the user account
+     *
+     * @return HasOne
+     */
     public function agent(): HasOne
     {
         return $this->hasOne(Agent::class);
+    }
+
+    /**
+     * Get the user preferences
+     *
+     * @return HasOne
+     */
+    public function userPreferences(): HasOne
+    {
+        return $this->hasOne(UserPreferences::class);
     }
 }

--- a/app/Models/UserPreferences.php
+++ b/app/Models/UserPreferences.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserPreferences extends Model
+{
+    use HasFactory;
+
+    /**
+     * Table for which this is the model
+     *
+     * @var string
+     */
+    protected $table = 'user_preferences';
+
+    /**
+     * Get the user for which these are the preferences
+     *
+     * @return BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/SolariumQueryService.php
+++ b/app/Services/SolariumQueryService.php
@@ -20,6 +20,7 @@
 namespace App\Services;
 
 use GuzzleHttp\Psr7\Query;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use Solarium\Client;
 
@@ -143,6 +144,10 @@ class SolariumQueryService {
             else {
                 $query->createFilterQuery('fq_' . 0)->setQuery($params['fq']);
             }
+        }
+        if (!Auth::check()) {
+            $query->createFilterQuery('fq_pubstatus')
+                    ->setQuery('publication_status:published');
         }
         return $query;
     }


### PR DESCRIPTION
Allow for draft Taxon Concepts that are visible only to VicFlora editors

- add publication_status column with values 'draft' and 'published' in taxon_concepts table
- draft pages are visible in search results and classification to logged in users only
- default value for publication_status can be set via user preferences (default in database is 'published').
